### PR TITLE
Fix KeyError bug when target_pathology is not specified

### DIFF
--- a/src/mimic_cxr_jpg_loader/dataset.py
+++ b/src/mimic_cxr_jpg_loader/dataset.py
@@ -26,7 +26,7 @@ class MIMICDataset:
     ):
         self.root = Path(root)
         self.split_path = Path(split_path)
-        self.target_pathology = str(target_pathology)
+        self.target_pathology = str(target_pathology) if target_pathology else None
 
         labels = self.get_labels()
 


### PR DESCRIPTION
When the `target_pathology` parameter is not specified, str(target_pathology) results in the string "None" instead of the None object. The result is a KeyError in the __getitem__() method. This change fixes that bug by explicitly checking for falsy arguments when converting the parameter to string.